### PR TITLE
WIP: Modified tests to more-closely mimic failure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 class test {
 
   case fact('osfamily') {
-    'windows': {
+    'windows',default: {
       $path = 'C:\file'
       $link = 'C:\link'
     }

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,47 +1,10 @@
 # comments
-define test::version(
-  Enum['absent','present'] $ensure               = 'present',
-  Optional[String]         $base_installdir      = undef,
-  Optional[String]         $windows_path_symlink = undef,
+define test::version (
+  Enum['absent','present'] $ensure = 'present',
 ) {
 
-  if $::osfamily == 'Windows' {
-    $package_ensure = $ensure
-
-    $installdir = $base_installdir ? {
-      undef   => 'd:/apps/productdir',
-      default => $base_installdir,
-    }
-
-    validate_absolute_path($installdir)
-
-    $safe_name = regsubst($name, ' ', '_')
-    $log_file = "D:\\java-${safe_name}.log"
-
-    $package_install_options = ["INSTALLDIR=\"${installdir}\"", '/L*V', "\"${log_file}\""]
-
-    if $windows_path_symlink {
-
-      validate_absolute_path($windows_path_symlink)
-
-      $link_ensure = $package_ensure ? {
-        'absent' => 'absent',
-        default  => 'link',
-      }
-
-      file { $windows_path_symlink:
-        ensure => $link_ensure,
-        target => $installdir,
-        force  => true,
-      }
-    }
-  } else {
-    $package_ensure = $ensure
-    $package_install_options = []
+  package { 'java':
+    ensure => $ensure,
   }
 
-  package { 'java' :
-    ensure          => $package_ensure,
-    install_options => $package_install_options
-  }
 }

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,0 +1,47 @@
+# comments
+define test::version(
+  Enum['absent','present'] $ensure               = 'present',
+  Optional[String]         $base_installdir      = undef,
+  Optional[String]         $windows_path_symlink = undef,
+) {
+
+  if $::osfamily == 'Windows' {
+    $package_ensure = $ensure
+
+    $installdir = $base_installdir ? {
+      undef   => 'd:/apps/productdir',
+      default => $base_installdir,
+    }
+
+    validate_absolute_path($installdir)
+
+    $safe_name = regsubst($name, ' ', '_')
+    $log_file = "D:\\java-${safe_name}.log"
+
+    $package_install_options = ["INSTALLDIR=\"${installdir}\"", '/L*V', "\"${log_file}\""]
+
+    if $windows_path_symlink {
+
+      validate_absolute_path($windows_path_symlink)
+
+      $link_ensure = $package_ensure ? {
+        'absent' => 'absent',
+        default  => 'link',
+      }
+
+      file { $windows_path_symlink:
+        ensure => $link_ensure,
+        target => $installdir,
+        force  => true,
+      }
+    }
+  } else {
+    $package_ensure = $ensure
+    $package_install_options = []
+  }
+
+  package { 'java' :
+    ensure          => $package_ensure,
+    install_options => $package_install_options
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -11,12 +11,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
         "2012 R2"

--- a/spec/classes/test_spec.rb
+++ b/spec/classes/test_spec.rb
@@ -1,12 +1,50 @@
 require 'spec_helper'
 
-describe 'test' do
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
-    context "on #{os}" do
-      let(:facts) { os_facts }
+# describe 'test' do
+#   on_supported_os(facterversion: '2.4').each do |os, os_facts|
+#     context "on #{os}" do
+#       let(:facts) { os_facts }
+#
+#       #it { is_expected.to compile }
+#       it { should compile.with_all_deps }
+#     end
+#   end
+# end
 
-      #it { is_expected.to compile }
-      it { should compile.with_all_deps }
+describe 'test' do
+
+  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+
+    os_facts.merge!({ :external_repo_package => 'http://softwarelibrary.wellsfargo.com:12080/mrc-packages',
+                      :external_repo_yum => 'http://softwarelibrary.wellsfargo.com:12080/yum' })
+
+    context "on #{os}" do
+
+      if os_facts[:operatingsystem] == 'windows'
+        windows_facts = { :wf_domain => 'AD-ENT', :is_bunsen => true }
+        let(:facts) { os_facts.merge(windows_facts) }
+        # let :pre_condition do
+        #   <<-EOF
+        #   File {
+        #     provider => 'posix',
+        #   }
+        #   EOF
+        # end
+
+        it { should compile }
+
+      elsif os_facts[:operatingsystem] == 'RedHat'
+        let(:facts) { os_facts }
+
+      end
+
+      # let(:facts) { os_facts }
+
+      # it { should compile.with_all_deps }
+      it { should contain_class('test') }
+
     end
+
   end
+
 end

--- a/spec/classes/test_spec.rb
+++ b/spec/classes/test_spec.rb
@@ -15,14 +15,10 @@ describe 'test' do
 
   on_supported_os(facterversion: '2.4').each do |os, os_facts|
 
-    os_facts.merge!({ :external_repo_package => 'http://softwarelibrary.wellsfargo.com:12080/mrc-packages',
-                      :external_repo_yum => 'http://softwarelibrary.wellsfargo.com:12080/yum' })
-
     context "on #{os}" do
 
       if os_facts[:operatingsystem] == 'windows'
-        windows_facts = { :wf_domain => 'AD-ENT', :is_bunsen => true }
-        let(:facts) { os_facts.merge(windows_facts) }
+        let(:facts) { os_facts }
         # let :pre_condition do
         #   <<-EOF
         #   File {

--- a/spec/defines/test_spec.rb
+++ b/spec/defines/test_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'test::version' do
+  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+    context "on #{os}" do
+      let(:title) { 'test_title' }
+      let(:facts) { os_facts }
+      let(:params) { { 'windows_path_symlink' => 'c:/Program Files/productdir' } }
+
+      #it { is_expected.to compile }
+      it { should compile.with_all_deps }
+    end
+  end
+end

--- a/spec/defines/test_spec.rb
+++ b/spec/defines/test_spec.rb
@@ -5,10 +5,8 @@ describe 'test::version' do
     context "on #{os}" do
       let(:title) { 'test_title' }
       let(:facts) { os_facts }
-      let(:params) { { 'windows_path_symlink' => 'c:/Program Files/productdir' } }
 
-      #it { is_expected.to compile }
-      it { should compile.with_all_deps }
+      it { should compile }
     end
   end
 end


### PR DESCRIPTION
__DO_NOT_MERGE__

Created this to demonstrate the error:

```
test::version
  on windows-2012 R2-x64
    should compile into a catalogue without dependency cycles (FAILED - 1)
  on windows-2012-x64
    should compile into a catalogue without dependency cycles

Failures:

  1) test::version on windows-2012 R2-x64 should compile into a catalogue without dependency cycles
     Failure/Error: it { should compile.with_all_deps }
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/package: Could not autoload puppet/provider/package/windows: uninitialized constant Puppet::Util::Windows at /Users/wilsjoel/puppet_workspace/reidmv-test/spec/fixtures/modules/test/manifests/version.pp:43:3 at line 2 on node .ent.wfb.bank.corp
     # ./spec/defines/test_spec.rb:11:in `block (4 levels) in <top (required)>'

Finished in 2.45 seconds (files took 2.22 seconds to load)
6 examples, 1 failure

Failed examples:

rspec './spec/defines/test_spec.rb[1:1:1]' # test::version on windows-2012 R2-x64 should compile into a catalogue without dependency cycles
```